### PR TITLE
Fix zsh completion guards and add codex

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -28,7 +28,7 @@ fi
 # TODO: is there some autonomous way to filter out a specific message from stderr?
 [[ -r ~/.ssh/personal/Adams-MBP_github ]] && ssh-add ~/.ssh/personal/Adams-MBP_github > /dev/null 2>&1
 
-[[ /usr/local/bin/kubectl ]] && source <(kubectl completion zsh)
+command -v codex &>/dev/null && eval "$(codex completion zsh)"
 
 # Updates PATH for the Google Cloud SDK.
 source_if_exists '/Users/adam/google-cloud-sdk/path.zsh.inc'
@@ -43,6 +43,6 @@ source_if_exists /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highligh
 source_if_exists "${HOME}/.zshrc"
 
 # https://medium.com/marvelous-mlops/the-rightway-to-install-python-on-a-mac-f3146d9d9a32
-eval "$(pyenv init -)"
-if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+command -v pyenv &>/dev/null && eval "$(pyenv init -)"
+command -v pyenv-virtualenv-init &>/dev/null && eval "$(pyenv virtualenv-init -)"
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
- Removed redundant `kubectl completion zsh` sourcing — brew already installs `_kubectl` into site-functions, picked up by `compinit`
- Added guarded `codex completion zsh` — codex doesn't ship brew completions, so explicit eval is needed
- Replaced unguarded `eval "$(pyenv init -)"` and `which`-based pyenv-virtualenv check with consistent `command -v` guards

## Test plan
- [ ] Open new zsh shell, verify no errors on startup
- [ ] Verify `codex <tab>` produces completions
- [ ] Verify `kubectl <tab>` still works (via brew compinit)
- [ ] Verify `pyenv <tab>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell configuration initialization with conditional tool checks for improved robustness.
  * Switched completion provider from kubectl to codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->